### PR TITLE
Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ First install the gem:
 
     gem install philosophies-suspenders
 
+Or update if you already have the gem installed:
+
+    gem update philosophies-suspenders
+
 Then run:
 
     philosophies-suspenders projectname

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,5 +1,5 @@
 module Suspenders
   RAILS_VERSION = "4.2.3"
   RUBY_VERSION = IO.read("#{File.dirname(__FILE__)}/../../.ruby-version").strip
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
@taboularasa Preps release to include the removal of `high_voltage`.

The version numbering of this tool is interesting: since other libs/apps/etc don't depend on it, semver isn't very valuable here... So, while although this could be considered a "breaking change" since it removes previous functionality, I only incremented the patch number because its such a small change. Thoughts?
