### PR TITLE
Exclude specs from rubocop blocklength check

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -23,3 +23,8 @@ AllCops:
     - "config/**/*"
     - "Rakefile"
     - "spec/i18n_spec.rb"
+
+BlockLength:
+  Exclude:
+    - "spec/**/*"
+    - "app/admin/**/*"


### PR DESCRIPTION
@patbenatar 